### PR TITLE
feat: add --lean-version-tag parameter for offline sorrys

### DIFF
--- a/src/offline_sorries.py
+++ b/src/offline_sorries.py
@@ -127,7 +127,7 @@ def process_lean_file(relative_path: Path, repo_path: Path, repl_binary: Path) -
             
         return results
 
-def process_lean_repo(repo_path: Path, lean_data: Path, subdir: str | None = None) -> list:
+def process_lean_repo(repo_path: Path, lean_data: Path, subdir: str | None = None, version_tag: str | None = None) -> list:
     """Process all Lean files in a repository using the REPL.
     
     Args:
@@ -149,7 +149,7 @@ def process_lean_repo(repo_path: Path, lean_data: Path, subdir: str | None = Non
                 - endColumn: int, ending column number
             - blame: dict, git blame information for the sorry line
     """
-    repl_binary = setup_repl(lean_data)
+    repl_binary = setup_repl(lean_data, version_tag)
     
     # Build list of files to process
     if subdir:
@@ -189,6 +189,8 @@ def main():
                        help='Directory for repository checkouts (default: lean_data)')
     parser.add_argument('--dir', type=str,
                        help='Subdirectory to search for Lean files (default: entire repository)')
+    parser.add_argument('--lean-version-tag', type=str,
+                       help='Lean version tag to used by REPL (default: most recent version of Lean available on REPL)')
     args = parser.parse_args()
     
     lean_data = Path(args.lean_data_dir)
@@ -205,7 +207,7 @@ def main():
         build_lean_project(checkout_path)
         
         # Process Lean files
-        sorries = process_lean_repo(checkout_path, lean_data, args.dir)
+        sorries = process_lean_repo(checkout_path, lean_data, args.dir, args.lean_version_tag)
         
         # Get repository metadata
         metadata = get_repo_metadata(checkout_path)

--- a/src/repl_api.py
+++ b/src/repl_api.py
@@ -7,8 +7,13 @@ from git import Repo
 import time
 import select
 
-def setup_repl(lean_data: Path) -> Path:
-    """Clone and build the REPL repository."""
+def setup_repl(lean_data: Path, version_tag: str | None = None) -> Path:
+    """Clone and build the REPL repository.
+    
+    Args:
+        lean_data: Path where the REPL should be cloned
+        version_tag: Optional git tag to checkout. If None, uses latest version
+    """
     repl_dir = lean_data / "repl"
     if not repl_dir.exists():
         print("Cloning REPL repository...")
@@ -16,6 +21,10 @@ def setup_repl(lean_data: Path) -> Path:
             "https://github.com/leanprover-community/repl",
             repl_dir
         )
+        
+        if version_tag is not None:
+            print(f"Checking out REPL at tag: {version_tag}")
+            repo.git.checkout(version_tag)
         
         print("Building REPL...")
         result = subprocess.run(["lake", "build"], cwd=repl_dir)


### PR DESCRIPTION
Before this change REPL returned an error when the version of the lean project didn't match the most recent version of REPL. The version tag parameter allows users to specify the lean version that REPL uses that the version of the Lean project match the version of REPL.

Modify `src/repl_api.py` to checkout the REPL repo at this version.

The default is still the most recent version of REPL available.