### PR TITLE
fix: add lean_data to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 lean/
 lean_files/
 DATA/
+lean_data
 src/lean_data
 src/lean_data.old
 


### PR DESCRIPTION
`offline_sorries` creates the lean_data directory when running in the repo root