### PR TITLE
fix: remove `lake update` step from offline_sorries.py

### DIFF
--- a/src/sorryscraper/scripts/offline_sorries.py
+++ b/src/sorryscraper/scripts/offline_sorries.py
@@ -27,12 +27,6 @@ def build_lean_project(repo_path: Path):
     if result.returncode != 0:
         raise Exception("lake exe cache get failed")
     
-    # First update all dependencies
-    print("Updating dependencies...")
-    result = subprocess.run(["lake", "update"], cwd=repo_path)
-    if result.returncode != 0:
-        raise Exception("lake update failed")
-    
     print("Building project...")
     result = subprocess.run(["lake", "build"], cwd=repo_path)
     if result.returncode != 0:


### PR DESCRIPTION
`lake update` updates dependencies. This could cause a case where the sorry we are reproducing locally has a different set of dependencies from the remote.