### PR TITLE
Lean version handling

### DIFF
--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -263,8 +263,9 @@ def build_database(repo_url: str, branch: str | None = None,
     # Process Lean files to find sorries
     sorries = process_lean_repo(checkout_path, lean_data, subdir, lean_version)
     
-    # Get repository metadata
+    # Get repository metadata and add lean_version
     metadata = get_repo_metadata(checkout_path)
+    metadata["lean_version"] = lean_version
     
     # Combine results
     results = {

--- a/src/sorrydb/database/build_database.py
+++ b/src/sorrydb/database/build_database.py
@@ -185,8 +185,46 @@ def process_lean_repo(repo_path: Path, lean_data: Path, subdir: str | None = Non
     return results
 
 
+def get_repo_lean_version(repo_path: Path) -> str:
+    """
+    Extract the Lean version from the lean-toolchain file in the repository.
+    
+    Args:
+        repo_path: Path to the repository root
+        
+    Returns:
+        str: The Lean version (e.g., 'v4.17.0-rc1')
+        
+    Raises:
+        FileNotFoundError: If the lean-toolchain file doesn't exist
+        ValueError: If the lean-toolchain file has an unexpected format
+        IOError: If there's an error reading the file
+    """
+    toolchain_path = repo_path / "lean-toolchain"
+    
+    if not toolchain_path.exists():
+        raise FileNotFoundError(f"No lean-toolchain file found at {toolchain_path}")
+    
+    try:
+        # Read the lean-toolchain file
+        toolchain_content = toolchain_path.read_text().strip()
+        
+        # The format of lean-toolchain is "leanprover/lean4:v4.17.0-rc1"
+        # Extract the version part after the colon
+        if ':' in toolchain_content:
+            lean_version = toolchain_content.split(':', 1)[1]
+            print(f"Extracted lean version {lean_version} from {toolchain_path}")
+            return lean_version
+        else:
+            raise ValueError(f"Unexpected format in lean-toolchain: {toolchain_content}")
+            
+    except IOError as e:
+        raise IOError(f"Error reading lean-toolchain file: {e}")
+
+
+
 def build_database(repo_url: str, branch: str | None = None, 
-                  lean_data: Path | None = None, subdir: str | None = None, lean_version_tag: str | None = None):
+                  lean_data: Path | None = None, subdir: str | None = None):
     """
     Comprehensive function that prepares a repository, builds a Lean project, 
     processes it to find sorries, and collects repository metadata.
@@ -213,9 +251,17 @@ def build_database(repo_url: str, branch: str | None = None,
     
     # Build the Lean project
     build_lean_project(checkout_path)
+
+    # Get Lean version from repo
+    try:
+        lean_version = get_repo_lean_version(checkout_path)
+    except (FileNotFoundError, ValueError, IOError) as e:
+        print(f"Encountered error when trying to get lean version: {e}")
+        print("Continuing without specific Lean version")
+        lean_version = None
     
     # Process Lean files to find sorries
-    sorries = process_lean_repo(checkout_path, lean_data, subdir, lean_version_tag)
+    sorries = process_lean_repo(checkout_path, lean_data, subdir, lean_version)
     
     # Get repository metadata
     metadata = get_repo_metadata(checkout_path)

--- a/src/sorrydb/repro/repl_api.py
+++ b/src/sorrydb/repro/repl_api.py
@@ -14,9 +14,16 @@ def setup_repl(lean_data: Path, version_tag: str | None = None) -> Path:
         lean_data: Path where the REPL should be cloned
         version_tag: Optional git tag to checkout. If None, uses latest version
     """
-    repl_dir = lean_data / "repl"
+    # Create a directory name that includes the version tag
+    if version_tag is not None:
+        sanitized_tag = version_tag.replace('.', '_').replace('-', '_')
+        repl_dir = lean_data / f"repl_{sanitized_tag}"
+    else:
+        # TODO: We might need to make this a "most recent version of sorts"
+        repl_dir = lean_data / "repl"
+    
     if not repl_dir.exists():
-        print("Cloning REPL repository...")
+        print(f"Cloning REPL repository into {repl_dir}...")
         repo = Repo.clone_from(
             "https://github.com/leanprover-community/repl",
             repl_dir

--- a/src/sorrydb/scripts/offline_sorries.py
+++ b/src/sorrydb/scripts/offline_sorries.py
@@ -16,8 +16,6 @@ def main():
                        help='Directory for repository checkouts (default: lean_data)')
     parser.add_argument('--dir', type=str,
                        help='Subdirectory to search for Lean files (default: entire repository)')
-    parser.add_argument('--lean-version-tag', type=str,
-                       help='Lean version tag to used by REPL (default: most recent version of Lean available on REPL)')
     args = parser.parse_args()
     
     lean_data = Path(args.lean_data_dir)
@@ -29,7 +27,6 @@ def main():
         branch=args.branch,
         lean_data=lean_data,
         subdir=args.dir,
-        lean_version_tag=args.lean_version_tag
     )
     
     # Write results

--- a/tests/test_build_database.py
+++ b/tests/test_build_database.py
@@ -1,0 +1,20 @@
+from sorrydb.database.build_database import build_database
+
+
+def test_build_database_with_mutiple_lean_versions():
+    """
+    Verify that the database builder can handle repositories
+    that use different versions of Lean.
+    
+    sorryClientTestRepoMath uses v4.17.0-rc1 and sorryClientTestRepo uses v4.16.0
+    """
+    mathRepoResults = build_database(
+        repo_url='https://github.com/austinletson/sorryClientTestRepoMath',
+    )
+
+    assert len(mathRepoResults["sorries"]) > 0
+    repoResults = build_database(
+        repo_url='https://github.com/austinletson/sorryClientTestRepo',
+    )
+
+    assert len(repoResults["sorries"]) > 0


### PR DESCRIPTION
This PR makes several improvements to lean version handling:

- automatically detect the lean version of a repo (and remove the cli option)
- pull different versions of REPL for each lean version and store them in separate repos
- the metadata section of build_database results includes the lean version

Additionally I added a test which builds both the test repos to verify that two repos of different versions both produce sorries. This test fails on master.

Closes #13

